### PR TITLE
bump nvm version to 0.31.0

### DIFF
--- a/provisioning/vars/nvm.yml
+++ b/provisioning/vars/nvm.yml
@@ -1,6 +1,6 @@
 ---
 nvm_env: user
-nvm_version: v0.29.0
+nvm_version: v0.31.0
 nvm_default_node_version: stable
 
 nvm_node_versions:


### PR DESCRIPTION
Version 0.29.0 was throwing the following error
```
Installing node v1.0 and greater from source is not currently supported
```